### PR TITLE
Updates the package to be a proper VCS package

### DIFF
--- a/pkgbuild/PKGBUILD
+++ b/pkgbuild/PKGBUILD
@@ -1,15 +1,23 @@
-pkgname=bigbashview
-pkgver=$(curl https://raw.githubusercontent.com/biglinux/bigbashview/master/bigbashview/usr/lib/bbv/globaldata.py | grep APP_VERSION  | cut -f2 -d\")_$(date +"%Y_%m_%d_%H_%M")
-pkgrel=2
+_pkgname=bigbashview
+pkgname="${_pkgname}-git"
+pkgver=3.8.1_2023_07_26
+pkgrel=1
+provides="${_pkgname}"
+conflicts="${_pkgname}"
 arch=('any')
 license=('GPL')
 url="https://github.com/biglinux/bigbashview"
-pkgdesc="BigBashView is a python app to run Bash+HTML in a Desktop WebView"
-depends=('python-pyqt5-webengine' 'python-six' 'webkit2gtk-4.1' 'ttf-lato' 'python-setproctitle' 'bbv-webpy' 'bootstrap')
+pkgdesc="A python app to run Bash+HTML in a Desktop WebView"
+depends=('pyside6' 'python-six' 'webkit2gtk-4.1' 'qt6-webengine')
 source=("git+https://github.com/biglinux/bigbashview.git")
 md5sums=(SKIP)
 
+pkgver() {
+    echo -n $(grep APP_VERSION ${srcdir}/${_pkgname}/${_pkgname}/usr/lib/bbv/globaldata.py | cut -f2 -d\")
+    echo _$(date +"%Y_%m_%d")
+}
+
 package() {
     mkdir -p "${pkgdir}/usr" "${pkgdir}/usr/lib"
-    cp -r "${srcdir}/bigbashview/bigbashview/usr/" "${pkgdir}/"
+    cp -r "${srcdir}/${_pkgname}/${_pkgname}/usr/" "${pkgdir}/"
 }


### PR DESCRIPTION
I stumbled upon this via biglinux-noise-reduction-pipewire from AUR. Building the AUR package doesn't work and seems to be largely based on this package:

https://aur.archlinux.org/packages/bigbashview

I updated this package to make it work on a current Arch installation - not sure if the person that put it there is watching :-)