### PR TITLE
fix availableGeometry == None

### DIFF
--- a/bigbashview/usr/lib/bbv/ui/qt.py
+++ b/bigbashview/usr/lib/bbv/ui/qt.py
@@ -259,16 +259,21 @@ class Window(QWidget):
     def set_size(self, width, height, window_state):
         # Set the window size and position based on the provided arguments
         display = self.app.screenAt(QCursor().pos())
-        size = display.availableGeometry()
-        if width <= 0:
-            width = int(size.width()/2)
-        if height <= 0:
-            height = int(size.height()/2)
+        if display is None:
+            width = 1024
+            height = 600
+        else:
+            size = display.availableGeometry()
+            if width <= 0:
+                width = int(size.width()/2)
+            if height <= 0:
+                height = int(size.height()/2)
+
+            cp = display.availableGeometry().center()
+            qr.moveCenter(cp)
 
         self.resize(width, height)
         qr = self.frameGeometry()
-        cp = display.availableGeometry().center()
-        qr.moveCenter(cp)
         self.move(qr.topLeft())
         if window_state == "fixed":
             self.setFixedSize(width, height)


### PR DESCRIPTION
fix bug availableGeometry in wayland

http://127.0.0.1:19000/
Traceback (most recent call last):
  File "/usr/lib/bbv/bigbashview.py", line 24, in <module>
    app.run()
  File "/usr/lib/python3.12/bbv/main.py", line 302, in run
    self.window.set_size(self.width, self.height, self.window_state)
  File "/usr/lib/python3.12/bbv/ui/qt.py", line 266, in set_size
    size = display.availableGeometry()
           ^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'availableGeometry'
